### PR TITLE
Update __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,7 +28,7 @@ class SpellingSkill(MycroftSkill):
     @intent_handler(IntentBuilder("").require("Spell").require("Word"))
     def handle_spell(self, message):
         word = message.data.get("Word")
-        spelled_word = '. '.join(word).upper()
+        spelled_word = '; '.join(word).upper()
 
         self.enclosure.deactivate_mouth_events()
         self.speak(spelled_word)


### PR DESCRIPTION
Changed the delimited used in the 'spelled_word - '. '.join(word.upper()' line within the 'handle_spell' function from a perion ( . ) to a semicolon ( ; ).  The period caused an issue pronouncing the letter 'M' when the Google Voice engine was used.  Mimic will be adding the semicolon as a delay as well.